### PR TITLE
Fix: ztsd long window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddit-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 repository = "https://github.com/wheynelau/pushshift-rs"
 
@@ -27,8 +27,17 @@ simd-json = "0.17.0"
 inherits = "release"
 codegen-units = 1
 lto = "fat"
+strip = true
 
+[profile.thin]
+inherits = "release"
+lto = "thin"
 
-[profile.release]
-codegen-units = 1
-lto = "fat"
+[[bench]]
+name = "json_bench"
+harness = false
+
+[[bench]]
+name = "subreddit_lookup_bench"
+harness = false
+

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Output must end with `.jsonl` or `.zst` (the extension is required and validated
 ### Arguments
 
 - `-i, --input` - Input file(s), supports glob patterns like `*.zst`
-- `-n, --names` - Subreddit names to filter (space-separated)
+- `-n, --names` - Subreddit names to filter (space-separated, case insensitive)
 - `-o, --output` - Output file pattern. Supports `{basename}` and `{subreddit}` placeholders
 - `-l, --level` - Compression level for `.zst` output (default: 3, range 1-22). Higher levels = better compression but slower. Level 3 balances speed and size. Pushshift archives use level 22 for maximum compression
 - `--workers` - Number of parallel worker threads for `zstd` compression (default: 0, single-threaded). Set to 1 or higher to enable multithreading

--- a/src/common/reader.rs
+++ b/src/common/reader.rs
@@ -1,33 +1,36 @@
-use anyhow::{Error, bail};
+use anyhow::{Context, Error, bail};
 use indicatif::ProgressBar;
-/// Handles the reading of files
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use zstd::stream::read::Decoder;
 
+/// Handles the reading of files
 pub fn setup_reader<P: AsRef<Path>>(
     input_path: P,
     pb: &ProgressBar,
 ) -> Result<Box<dyn BufRead>, Error> {
     let path = input_path.as_ref();
-    let thread_file = File::open(path).expect("Failed to open input file");
-    let progress_reader = pb.wrap_read(thread_file);
-    let reader: Box<dyn BufRead> = if path
+    let file =
+        File::open(path).context(format!("Failed to open input file: {}", path.display()))?;
+    let progress_reader = pb.wrap_read(file);
+
+    if path
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
     {
-        // Use zstd decoder for .zst files
-        let decoder = Decoder::new(progress_reader).expect("Failed to create zstd decoder");
-        Box::new(BufReader::new(decoder))
+        let mut decoder = zstd::stream::read::Decoder::new(progress_reader)
+            .context("Failed to create zstd decoder")?;
+        decoder.window_log_max(31)?;
+        Ok(Box::new(BufReader::new(decoder)))
     } else if path
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
     {
-        // Read directly for other files (e.g., .jsonl)
-        Box::new(BufReader::new(progress_reader))
+        Ok(Box::new(BufReader::new(progress_reader)))
     } else {
-        bail!("Unsupported file type");
-    };
-    Ok(reader)
+        bail!(
+            "Unsupported file type: {}",
+            path.extension().unwrap_or_default().to_string_lossy()
+        );
+    }
 }


### PR DESCRIPTION
When working on longer files, `ztsd` silently fails without errors:

With reference to a post on [reddit](https://www.reddit.com/r/pushshift/comments/wv4wxi/problem_decompressing_zst_files_after_202107/) 
it seems like it was a window issue. Verifying with `zstdcat` also confirms, with the error:

```bash
zstdcat RS_2021-09.zst 
RS_2021-09.zst : Decoding error (36) : Frame requires too much memory for decoding 
RS_2021-09.zst : Window size larger than maximum : 2147483648 > 134217728 
RS_2021-09.zst : Use --long=31 or --memory=2048MB
```

The change defaults all decompressions to long window size. 

Closes #1

